### PR TITLE
Skip minimization in the fully interacting state

### DIFF
--- a/sensitivity-analysis/yank/run-lsf-lilac.sh
+++ b/sensitivity-analysis/yank/run-lsf-lilac.sh
@@ -17,5 +17,5 @@
 # job name (default = name of script file)
 #BSUB -J "sensitivity-lilac"
 
-build_mpirun_configfile --hostfilepath hostfile.${LSB_JOBNAME} --configfilepath configfile.${LSB_JOBNAME} "yank script --yaml=${LSB_JOBNAME}.yaml"
+build_mpirun_configfile --hostfilepath hostfile.${LSB_JOBNAME} --configfilepath configfile.${LSB_JOBNAME} "python run_yank.py --yaml=${LSB_JOBNAME}.yaml"
 mpiexec.hydra -f hostfile.${LSB_JOBNAME} -configfile configfile.${LSB_JOBNAME}

--- a/sensitivity-analysis/yank/sensitivity-lilac.yaml
+++ b/sensitivity-analysis/yank/sensitivity-lilac.yaml
@@ -8,7 +8,7 @@ options:
   processes_per_experiment: 1
   hydrogen_mass: 3.0 * amu
   checkpoint_interval: 100
-  switch_experiment_interval: 100
+  switch_phase_interval: 100
   alchemical_pme_treatment: exact
 
 molecules:

--- a/sensitivity-analysis/yank/sensitivity-titan.yaml
+++ b/sensitivity-analysis/yank/sensitivity-titan.yaml
@@ -8,7 +8,7 @@ options:
   processes_per_experiment: 1
   hydrogen_mass: 3.0 * amu
   checkpoint_interval: 10
-  switch_experiment_interval: 100
+  switch_phase_interval: 100
 
   #annihilate_electrostatics: yes
   #annihilate_sterics: no


### PR DESCRIPTION
This PR merges into the `sensitivity` branch.

Modify the driver script to skip the fully interacting state minimization and minimize only the noninteracting state.

Also fixes a typo in the `run-lsf-lilac.sh` shell script to make it use the `run_yank.py` driver script, and change the YAML script to use `switch_phase_interval` instead of `switch_experiment_interval`.